### PR TITLE
Remove unused discord bot and add new network with fixed gateway IP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     restart: always
     ports:
       - 8000:8000
+    networks:
+      - gpt_research_network
       
   gptr-nextjs:
     pull_policy: build
@@ -36,6 +38,8 @@ services:
     restart: always
     ports:
       - 3000:3000
+    networks:
+      - gpt_research_network
 
   gpt-researcher-tests:
     image: gptresearcher/gpt-researcher-tests
@@ -52,18 +56,13 @@ services:
       python -m pytest tests/report-types.py &&
       python -m pytest tests/vector-store.py
       "
-  
-  discord-bot:
-    build:
-      context: ./docs/discord-bot
-      dockerfile: Dockerfile.dev
-    environment:
-      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}
-      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID}
-    volumes:
-      - ./docs/discord-bot:/app
-      - /app/node_modules
-    ports:
-      - 3001:3000
-    profiles: ["discord"]
-    restart: always
+    networks:
+      - gpt_research_network
+
+networks:
+  gpt_research_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.0.0/24
+          gateway: 172.16.0.1


### PR DESCRIPTION
Remove the `discord-bot` service and add a new network with a fixed gateway IP in `docker-compose.yml`.

* Remove the `discord-bot` service definition.
* Add a new network named `gpt_research_network` with a fixed gateway IP.
* Add all services under the `gpt_research_network`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eric2788/gpt-researcher/pull/1?shareId=9034066f-56e5-4dc8-bb7f-e6ffec4ab548).